### PR TITLE
[TOP-349] fix a memory leak

### DIFF
--- a/vips.go
+++ b/vips.go
@@ -480,6 +480,7 @@ func vipsToBytes(imgBuf []byte) ([]byte, error) {
 
 	defer C.free(buf)
 	defer C.vips_error_clear()
+	defer C.g_object_unref(C.gpointer(image))
 
 	return C.GoBytes(unsafe.Pointer(buf), C.int(length)), nil
 }


### PR DESCRIPTION
try to fix a memory leak identified in memory processor, but investigation shows it's deep in here.

verified with some data.

Without the fix

```
100 calls, at 1334MB
200 calls, at 2068MB
500 calls, at 4164MB
1000 calls, at 11160MB
```

With the fix

```
100 calls, at 860 MB
200 calls, at 905 MB
500 calls, at 932 MB
1000 calls, at 1081 MB
1500 calls, at 1061 MB
```
